### PR TITLE
exampleSite: Fix site name for compilation

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -5,7 +5,7 @@ title = "Pointy's"
 # Only use if exampleSite is inside theme folder
 themesDir = "../../"
 
-theme = "pointyfood"
+theme = "pointybubl"
 paginate = 8
 
 #sectionPagesMenu = "main"


### PR DESCRIPTION
I guess this was changed recently?